### PR TITLE
fix: update usage of withDeprecatedProps

### DIFF
--- a/src/ProductTour/Checkpoint.jsx
+++ b/src/ProductTour/Checkpoint.jsx
@@ -9,11 +9,10 @@ import CheckpointActionRow from './CheckpointActionRow';
 import CheckpointBody from './CheckpointBody';
 import CheckpointHeader from './CheckpointHeader';
 import messages from './messages';
-import withDeprecatedProps, { DeprTypes } from '../withDeprecatedProps';
 
 const Checkpoint = React.forwardRef(({
   body,
-  dismissButtonText,
+  dismissAltText,
   index,
   onBack,
   onDismiss,
@@ -106,7 +105,7 @@ const Checkpoint = React.forwardRef(({
         />
       </span>
       <CheckpointHeader
-        dismissAltText={dismissButtonText}
+        dismissAltText={dismissAltText}
         index={index}
         onDismiss={onDismiss}
         title={title}
@@ -135,7 +134,7 @@ Checkpoint.defaultProps = {
   advanceButtonText: null,
   backButtonText: null,
   body: null,
-  dismissButtonText: null,
+  dismissAltText: null,
   endButtonText: null,
   placement: 'top',
   title: null,
@@ -148,8 +147,8 @@ Checkpoint.propTypes = {
   backButtonText: PropTypes.node,
   /** The text displayed in the body of the Checkpoint */
   body: PropTypes.node,
-  /** **Deprecated** The text displayed on the button used to dismiss the tour for the given Checkpoint.  */
-  dismissButtonText: PropTypes.node,
+  /** The text used in the alt for the icon used to dismiss the tour for the given Checkpoint */
+  dismissAltText: PropTypes.string,
   /** The text displayed on the button used to end the tour for the given Checkpoint. */
   endButtonText: PropTypes.node,
   /** The current index of the given Checkpoint */
@@ -178,12 +177,5 @@ Checkpoint.propTypes = {
   /** The total number of Checkpoints in a tour */
   totalCheckpoints: PropTypes.number.isRequired,
 };
-
-export const CheckpointWithDeprecatedProp = withDeprecatedProps(Checkpoint, 'Checkpoint', {
-  dismissButtonText: {
-    deprType: DeprTypes.REMOVED,
-    message: 'The dismiss button was replaced with a close icon, button text is being used as alt text for the icon.',
-  },
-});
 
 export default Checkpoint;

--- a/src/ProductTour/CheckpointHeader.jsx
+++ b/src/ProductTour/CheckpointHeader.jsx
@@ -44,7 +44,7 @@ CheckpointHeader.defaultProps = {
 };
 
 CheckpointHeader.propTypes = {
-  /** Was deprecated dismissButtonText, now is being passed as alt text to the close icon */
+  /** The text used in the alt for the icon used to dismiss the tour for the given Checkpoint */
   dismissAltText: PropTypes.string,
   /** The current index of the given Checkpoint */
   index: PropTypes.number.isRequired,

--- a/src/ProductTour/README.md
+++ b/src/ProductTour/README.md
@@ -34,6 +34,7 @@ descriptive and readable.
       enabled: isTourEnabled,
       onDismiss: () => setIsTourEnabled(false),
       onEnd: () => setIsTourEnabled(false),
+      dismissAltText: '',
       checkpoints: [
         {
           advanceButtonText: 'Onward', // Override the default advanceButtonText above
@@ -41,6 +42,7 @@ descriptive and readable.
           placement: 'top',
           target: '#checkpoint-1',
           title: 'First checkpoint',
+          dismissAltText: '',
         },
         {
           body: "Here's the second checkpoint!",

--- a/src/ProductTour/index.jsx
+++ b/src/ProductTour/index.jsx
@@ -7,9 +7,17 @@ import Checkpoint from './Checkpoint';
 const ProductTour = React.forwardRef(({ tours }, ref) => {
   const tourValue = tours.find((tour) => tour.enabled);
   const {
-    enabled, checkpoints = [], startingIndex, onEscape, onEnd, onBack,
-    onDismiss: tourOnDismiss, advanceButtonText: tourAdvanceButtonText,
-    dismissButtonText: tourDismissButtonText, endButtonText: tourEndButtonText,
+    enabled,
+    checkpoints = [],
+    startingIndex,
+    onEscape,
+    onEnd,
+    onBack,
+    onDismiss: tourOnDismiss,
+    advanceButtonText: tourAdvanceButtonText,
+    // dismissButtonText: tourDismissButtonText,
+    dismissAltText: tourDismissAltText,
+    endButtonText: tourEndButtonText,
     backButtonText: tourBackButtonText,
   } = tourValue || {};
   const [currentCheckpointData, setCurrentCheckpointData] = useState(null);
@@ -17,8 +25,17 @@ const ProductTour = React.forwardRef(({ tours }, ref) => {
   const [isTourEnabled, setIsTourEnabled] = useState(false);
   const [prunedCheckpoints, setPrunedCheckpoints] = useState([]);
   const {
-    title, body, onAdvance, onDismiss, advanceButtonText, dismissButtonText,
-    endButtonText, backButtonText, placement, target,
+    title,
+    body,
+    onAdvance,
+    onDismiss,
+    advanceButtonText,
+    // dismissButtonText,
+    dismissAltText,
+    endButtonText,
+    backButtonText,
+    placement,
+    target,
   } = currentCheckpointData || {};
 
   /**
@@ -115,7 +132,7 @@ const ProductTour = React.forwardRef(({ tours }, ref) => {
       advanceButtonText={advanceButtonText || tourAdvanceButtonText}
       body={body}
       currentCheckpointData={currentCheckpointData}
-      dismissButtonText={dismissButtonText || tourDismissButtonText}
+      dismissAltText={dismissAltText || tourDismissAltText}
       endButtonText={endButtonText || tourEndButtonText}
       backButtonText={backButtonText || tourBackButtonText}
       index={index}
@@ -140,7 +157,7 @@ ProductTour.defaultProps = {
       advanceButtonText: '',
       backButtonText: '',
       body: '',
-      dismissButtonText: '',
+      dismissAltText: '',
       endButtonText: '',
       onAdvance: () => {},
       onDismiss: () => {},
@@ -148,7 +165,7 @@ ProductTour.defaultProps = {
       placement: 'top',
       title: '',
     },
-    dismissButtonText: '',
+    dismissAltText: '',
     endButtonText: '',
     onBack: () => {},
     onDismiss: () => {},
@@ -174,12 +191,12 @@ ProductTour.propTypes = {
       backButtonText: PropTypes.node,
       /** The text displayed in the body of the Checkpoint */
       body: PropTypes.node,
-      /** **Deprecated** The text displayed on the button used to dismiss the tour for the given Checkpoint.  */
-      dismissButtonText: PropTypes.node,
+      /** The text used in the alt for the icon used to dismiss the tour for the given Checkpoint */
+      dismissAltText: PropTypes.string,
       /** The text displayed on the button used to end the tour for the given Checkpoint
        * (overrides the `endButtonText` defined in the parent tour object). */
       endButtonText: PropTypes.node,
-      /** A function that runs when triggering the `onClick` event of the advance
+      /** A function that runs when triggering the `onCick` event of the advance
        * button for the given Checkpoint. */
       onAdvance: PropTypes.func,
       /** A function that runs when triggering the `onClick` event of the dismiss
@@ -198,8 +215,8 @@ ProductTour.propTypes = {
       /** The text displayed in the title of the Checkpoint */
       title: PropTypes.node,
     })),
-    /** **Deprecated** The text displayed on the button used to dismiss the tour for the given Checkpoint.  */
-    dismissButtonText: PropTypes.node,
+    /** The text used in the alt for the icon used to dismiss the tour for the given Checkpoint */
+    dismissAltText: PropTypes.string,
     /** Whether the tour is enabled. If there are multiple tours defined, only one should be enabled at a time. */
     enabled: PropTypes.bool.isRequired,
     /** The text displayed on the button used to end the tour. */
@@ -219,11 +236,76 @@ ProductTour.propTypes = {
   })),
 };
 
-export const ProductTourWithDeprecatedProp = withDeprecatedProps(ProductTour, 'ProductTour', {
-  dismissButtonText: {
-    deprType: DeprTypes.REMOVED,
-    message: 'The dismiss button was replaced with a close icon, button text is being used as alt text for the icon.',
+/**
+ * Checks if the given object has a deprecated/legacy `dismissButtonText` property.
+ * @param {Object} obj - The object to check
+ * @returns {boolean} - True if the object has a deprecated/legacy `dismissButtonText` property, false otherwise
+ */
+const hasDismissButtonText = (obj) => {
+  if ('dismissButtonText' in obj && !!obj.dismissButtonText) {
+    return true;
+  }
+  return false;
+};
+
+export default withDeprecatedProps(ProductTour, 'ProductTour', {
+  tours: {
+    deprType: DeprTypes.FORMAT,
+    message: "The dismissButtonText options in the 'tours' prop have been moved to 'dismissAltText'.",
+    /**
+     * Determines whether the given prop value contains the deprecated/legacy `dismissButtonText` property.
+     * @param {Object[]} propValue - The tours prop value to check
+     * @returns {boolean} True if the prop value contains the deprecated/legacy `dismissButtonText`
+     *  property, false otherwise
+     */
+    expect: (propValue) => {
+      if (!Array.isArray(propValue)) {
+        return true;
+      }
+      return !propValue.some((tour) => {
+        if (hasDismissButtonText(tour)) {
+          return true;
+        }
+        return Array.isArray(tour.checkpoints)
+          && tour.checkpoints.some(hasDismissButtonText);
+      });
+    },
+    /**
+     * Transforms the given prop value by updating the
+     * deprecated/legacy `dismissButtonText` property to
+     * `dismissAltText`, if the prop value is a string. Otherwise,
+     * the original `dismissButtonText` property is ignored.
+     * @param {Object[]} propValue - The tours prop value to transform
+     * @returns {Object[]} The transformed prop value
+     */
+    transform: (propValue) => {
+      const tours = propValue.map((tour) => {
+        const updatedTour = { ...tour };
+
+        // Replace tour level dismissButtonText with dismissAltText
+        if (hasDismissButtonText(tour)) {
+          if (typeof tour.dismissButtonText === 'string') {
+            updatedTour.dismissAltText = tour.dismissButtonText;
+          }
+        }
+
+        // Replace checkpoint level dismissButtonText with dismissAltText
+        if (Array.isArray(tour.checkpoints)) {
+          updatedTour.checkpoints = tour.checkpoints.map((checkpoint) => {
+            if (hasDismissButtonText(checkpoint)) {
+              const { dismissButtonText, ...rest } = checkpoint;
+              if (typeof dismissButtonText === 'string') {
+                return { ...rest, dismissAltText: dismissButtonText };
+              }
+            }
+            return checkpoint;
+          });
+        }
+        return updatedTour;
+      });
+
+      // Return the transformed tours
+      return tours;
+    },
   },
 });
-
-export default ProductTour;

--- a/src/withDeprecatedProps.tsx
+++ b/src/withDeprecatedProps.tsx
@@ -66,10 +66,17 @@ function withDeprecatedProps<T extends Record<string, any>>(
             acc[propName] = this.props[propName];
           }
           break;
-        case DeprTypes.MOVED_AND_FORMAT:
-          this.warn(`${componentName}: The prop '${propName}' has been moved to '${newName}' and expects a new format. ${message}`);
-          acc[newName!] = transform!(this.props[propName], this.props);
+        case DeprTypes.MOVED_AND_FORMAT: {
+          const propValue = this.props[propName];
+          let warningMessage = `${componentName}: The prop '${propName}' has been moved to '${newName}'`;
+          if (expect && !expect(propValue)) {
+            warningMessage += ' and expects a new format';
+          }
+          warningMessage += message ? `. ${message}` : '';
+          this.warn(warningMessage);
+          acc[newName!] = transform ? transform(propValue, this.props) : propValue;
           break;
+        }
         default:
           acc[propName] = this.props[propName];
           break;


### PR DESCRIPTION
## Description

Include a description of your changes here, along with a link to any relevant Jira tickets and/or Github issues.

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please request an a11y review for the PR in the [#wg-paragon](https://openedx.slack.com/archives/C02NR285KV4) Open edX Slack channel.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@openedx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
